### PR TITLE
Make the URL clickable

### DIFF
--- a/main.html
+++ b/main.html
@@ -100,7 +100,7 @@
                         <div id="qrcode" align="center"></div>
                         <br>
                         <br>
-                        <strong>URL:</strong> <span id="sharing-url"></span>
+                        <strong>URL:</strong> <a id="sharing-url"></a>
                     </div>
                     <br>
                     <br>
@@ -235,6 +235,8 @@
         $('#not-sharing').hide();
         $('.sharing-on').show();
         $('#sharing-url').html(url);
+        $('#sharing-url').attr('href', url);
+        $('#sharing-url').attr('target', '_blank');
         $('#qrcode').html('');
         new QRCode(
             document.getElementById("qrcode"), {


### PR DESCRIPTION
A simple contribution to make the URL clickable instead of copying and pasting....

This code has a problem.... The URL opens in a new window inside electron.
I don't know how electron works, but maybe this can help you guys:

```javascript
$(document).on('click', 'a[href^="http"]', function(event) {
    event.preventDefault();
    shell.openExternal(this.href);
});
```
or
```javascript
require("shell").openExternal("http://www.google.com")
```

Thanks for the great tool! :)