### PR TITLE
Fix overflow/scroll in parent container. fixes #158

### DIFF
--- a/main.html
+++ b/main.html
@@ -14,12 +14,11 @@
                 .container-fluid {
                     margin: 0 auto;
                     height: 100%;
-                    padding: 0px 0;
+                    padding: 0;
                 }
                 .content {
-                    height: 100%;
+                    height: calc(100% - 50px);
                     overflow: auto;
-                    padding-bottom: 50px;
                 }
                 #top-nav {
                     height: 50px;


### PR DESCRIPTION
## What's this PR for?

As seen in #158, #157 there is a CSS overflow problem in `body > .fluid-cointainer`, caused by the bottom padding set on `.content` being added to it's height of 100% (100% + 50px = 50px extra overflow). 


## How can it be reproduced?
Can be reproduced by keeping your mouse pointer in the header and scrolling.

You'll scroll away from the top-nav area with logout and mobile buttons and end up with 50px of white at the bottom of the container.


My PR fixes the overflow by removing that bottom padding and setting the content height to 100% - 50px (the height of #top-nav)