### PR TITLE
Hide body and content overflow

### DIFF
--- a/main.html
+++ b/main.html
@@ -10,6 +10,7 @@
                 html, body {
                     height: 100%;
                     width: 100%;
+                    overflow: hidden;
                 }
                 .container-fluid {
                     margin: 0 auto;
@@ -18,7 +19,7 @@
                 }
                 .content {
                     height: calc(100% - 50px);
-                    overflow: auto;
+                    overflow: hidden;
                 }
                 #top-nav {
                     height: 50px;


### PR DESCRIPTION
Try to fix a not necessary overflow.

On my pc the webview has an overflow that is not necessary, this appeas to be a "bug":

![image](https://cloud.githubusercontent.com/assets/10428035/17258259/639af4f6-559c-11e6-89c7-e830dfcc130e.png)

***
I changed the overflow value and tested locally.
Fixed for me:

![image](https://cloud.githubusercontent.com/assets/10428035/17258384/f6e3e560-559c-11e6-9191-52e905c2ed10.png)

That's all, thanks.
--also thanks for the great work in this app o/
