### PR TITLE
Added support for the scan-delay argument

### DIFF
--- a/login.html
+++ b/login.html
@@ -127,7 +127,26 @@
                                 Larger numbers increase search area but updates are slower.
                             </span>
                         </div>
+                        <br>
                     </div>
+
+                    <div class="col-xs-8 col-xs-offset-2">
+                        <div class="row">
+                            <div class="col-xs-6 col-xs-offset-3">
+                                <div class="col-xs-10 col-xs-offset-1">
+                                    <input id="scandelay" class="form-control"
+                                        type="number" placeholder="Delay (default 10)">
+                                </div>
+                            </div>
+                        </div>
+                        <br>
+                        <div class="row">
+                            <span>
+                                Numbers below the default value will lead to some pokemon being missed by the scanner.
+                            </span>
+                        </div>
+                    </div>
+
                     <!--<div class="col-xs-8 col-xs-offset-2">
                         <div class="row">
                             <div class="col-xs-12">
@@ -267,6 +286,7 @@
         // setupValueAndSetter('filter_type', $('#filter_type'));
         // setupValueAndSetter('pokeids', $('#pokeids'));
         setupValueAndSetter('radius', $('#radius'));
+        setupValueAndSetter('scandelay', $('#scandelay'));
 
         setupValue('last_lat', $('#lat'));
         setupValue('last_lon', $('#lon'));
@@ -374,6 +394,12 @@
         if ($('#radius').val() != '') {
             if (!$('#radius').val().match(/^[0-9]+$/)) {
                 alert('Invalid Radius. Only numbers allowed.');
+                return false;
+            }
+        }
+        if ($('#scandelay').val() != '') {
+            if (!$('#scandelay').val().match(/^[0-9]+$/)) {
+                alert('Invalid Delay. Only numbers allowed.');
                 return false;
             }
         }
@@ -539,6 +565,7 @@
             is_public: checked('is_public'),
             //fast_scan: checked('fast_scan'),
             radius: $('#radius').val(),
+            scandelay: $('#scandelay').val(),
             username: $('#ptc_username').val(),
             password: $('#ptc_password').val(),
             maps_api_key: $('#maps_api_key').val()

--- a/main.js
+++ b/main.js
@@ -244,6 +244,13 @@ function startPython(auth, code, lat, long, opts) {
       cmdLine.push('7');
     }
 
+    cmdLine.push('--scan-delay');
+    if (opts.scandelay && opts.scandelay != '') {
+      cmdLine.push(opts.scandelay);
+    } else {
+      cmdLine.push('10');
+    }
+
     // console.log(cmdLine);
     logData('Maps path: ' + path.join(__dirname, 'map'));
     logData('python ' + cmdLine.join(' '));


### PR DESCRIPTION
I've added support for the scan-delay (time delay between requests) argument.
![login_updated](https://cloud.githubusercontent.com/assets/4518410/17368786/d7f62a76-5995-11e6-8ae9-5e4e3cce4e49.jpg)

**Motivation for PR**
Niantic is making changes to the maximum amount of requests you can make on a regular basis. This input field allows users to adopt to these changes without waiting for an update: They can just enter the new value in the corresponding field.

**Testing**
Changes are being recognized, example of the application running with a scan-delay of 20 seconds:
![logging_20_delay](https://cloud.githubusercontent.com/assets/4518410/17368822/0009317a-5996-11e6-8515-a33c9ada3f79.jpg)

**Additional comments**
Code style was followed from what I see.
