### PR TITLE
Add virtualenv usage when running from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Development is currently done on OS X and tested on Windows 10. To get started, 
 
     brew install python node
     pip install virtualenv
+    virtualenv .
+    source bin/activate
     npm install
 
 To run the project, run:


### PR DESCRIPTION
Hey, it slipped my mind to do the `virtualenv .` and `source bin/activate` when installing & running this app from source. I presume that it should be executed in this order for it to work properly?